### PR TITLE
Encourage small PRs often + single concern PRs

### DIFF
--- a/docs/web-mobile-app-dev/frontend/dos-donts.md
+++ b/docs/web-mobile-app-dev/frontend/dos-donts.md
@@ -4,9 +4,19 @@ sidebar_position: 1
 
 # Dos and don'ts
 
-## Common mistakes and how to avoid them
+> **Document Creation:** 7 May, 2024. **Last Edited:** 10 July, 2024. **Authors:** Leesa Ward.
 
-> **Document Creation:** 7 May, 2024. **Last Edited:** 19 May, 2024. **Authors:** Leesa Ward.
+## Summary of things to do
+- ![Correct action](./img/icon-success.svg) Fork the existing repositories for the project(s) you need to work on to your own GitHub account, and do your work in that codebase.
+- ![Correct action](./img/icon-success.svg) Create a branch in your fork for each piece of work.
+- ![Correct action](./img/icon-success.svg) Use React for your front-end work, with the supporting tools and libraries described in this documentation such as TypeScript, Styled Components and React Router.
+- ![Correct action](./img/icon-success.svg) Use the provided [generator script](./new-components) to create new components.
+- ![Correct action](./img/icon-success.svg) Use TypeScript with a type (or interface) in place of PropTypes.
+- ![Correct action](./img/icon-success.svg) Use React function components in the first instance, or migrate if you have already developed a class component.
+- ![Correct action](./img/icon-success.svg) Raise small pull requests, often.
+- ![Correct action](./img/icon-success.svg) Keep pull requests limited to a single feature, change, or bugfix each. 
+
+## Common mistakes and how to avoid them
 
 ### Where to do your work
 
@@ -120,6 +130,31 @@ sidebar_position: 1
 <br/>
 
 ### How to submit your work
+<table>
+    <tr>
+        <th scope="row" style={{"text-align":"left","min-width":"12rem"}}>Mistake</th>
+        <td>![Error](./img/icon-warning.svg) Doing a lot of work over a long time in a single branch, then raising one huge pull request - often late in the trimester.</td>
+    </tr>
+    <tr>
+        <th scope="row" style={{"text-align":"left"}}>Why it's a mistake</th>
+        <td>
+        <p>![Explanation](./img/icon-info.svg) The larger the PR, the more complex it is to review, meaning that:</p>
+        <ul> 
+            <li>the review -> feedback -> changes -> re-review loop takes longer, so the whole team and project(s) benefitting from your contribution is delayed</li>
+            <li>mistakes and valuable technical feedback are more likely to be missed in reviews</li>
+            <li>it is harder to identify and fix merge conflicts, increasing the time you spend on tedious </li>
+            <li>contributions may not be merged at all because time runs out.</li>
+        </ul>
+      <p>Many team members submitting large PRs late in the trimester exacerbates this due to the increased workload on leaders and mentors.</p>
+         </td>
+    </tr>
+    <tr>
+        <th scope="row" style={{"text-align":"left"}}>What to do instead</th>
+        <td>![Correct action](./img/icon-success.svg) Raise small pull requests, often. For example, rather than waiting until you have completed a whole webpage, complete one component and submit a PR for that, then another for the next one, etc.</td>   
+    </tr>
+</table>
+
+<br/>
 
 <table>
     <tr>

--- a/docs/web-mobile-app-dev/frontend/getting-started.md
+++ b/docs/web-mobile-app-dev/frontend/getting-started.md
@@ -5,7 +5,7 @@ sidebar_label: Getting started
 
 # Getting started with a project
 
-> **Document Creation:** 23 March, 2024. **Last Edited:** 6 May, 2024. **Authors:** Leesa Ward.
+> **Document Creation:** 23 March, 2024. **Last Edited:** 10 July, 2024. **Authors:** Leesa Ward.
 
 ## Prerequisites
 - [Git](https://git-scm.com/downloads) installed
@@ -22,7 +22,7 @@ sidebar_label: Getting started
 - Git GUI such as GitKraken, SourceTree, GitHub Desktop (if you prefer this over working only with terminal commands)
 
 ## Getting Started
-1. Fork the repository to your own account
+1. Fork the repository you will be working on to your own account
    ![Screenshot of how to fork a repo](./img/fork-example.png)
 
 2. Clone the repository to your local machine
@@ -30,29 +30,30 @@ sidebar_label: Getting started
     git clone https://github.com/your-username/your-repo-name.git
     ```
    (or SSH if you have set up SSH access to your GitHub account)
-3. Create a branch for your current work, following the Capstone [Branching Guidelines](https://verdant-raindrop-f3e404.netlify.app/processes/quality-assurance/git-contributions-guide/#branching-guidelines)
+3. Select a task to work on from the [Planner Board](https://tasks.office.com/deakin365.onmicrosoft.com/en-US/Home/Planner/#/plantaskboard?groupId=d4b3d587-9b20-4ac0-9de2-b842fd9dce46&planId=TOGdCftBI0mZ937fEIW0jsgAHPsL). If a suitable task does not exist for you but you have identified something that needs to be done, create a task for it and assign yourself. If it is a large feature, break it up into small, discrete tasks.
+4. Create a branch for your current work, following the Capstone [Branching Guidelines](https://verdant-raindrop-f3e404.netlify.app/processes/quality-assurance/git-contributions-guide/#branching-guidelines)
     ```bash
     git branch <branch-name>
     ```
-4. Check out your branch
+5. Check out your branch
     ```bash
     git checkout <branch-name>
     ```
-5. Open your terminal and navigate to the project directory
+6. Open your terminal and navigate to the project directory
     ```bash
     cd path/to/your-repo-name
     ```
-6. Run `npm install` to install the project dependencies
+7. Run `npm install` to install the project dependencies
     ```bash
    npm install
     ```
-7. Run `npm run dev` to start the development server
+8. Run `npm run dev` to start the development server
     ```bash
     npm run dev
     ```
-8. Open a web browser and navigate to `http://localhost:5173` to view the application (or different port if specified in the terminal output).
-9. Make your changes.
-10. Commit your changes regularly and push your branch up to GitHub.
+9. Open a web browser and navigate to `http://localhost:5173` to view the application (or different port if specified in the terminal output).
+10. Make your changes.
+11. Commit your changes regularly and push your branch up to GitHub.
 
 
 ## Useful links

--- a/docs/web-mobile-app-dev/frontend/submitting-work.md
+++ b/docs/web-mobile-app-dev/frontend/submitting-work.md
@@ -4,8 +4,21 @@ sidebar_position: 9
 
 # Submitting code
 
-> **Document Creation:** 6 May, 2024. **Last Edited:** 6 May, 2024. **Authors:** Leesa Ward.
+> **Document Creation:** 6 May, 2024. **Last Edited:** 10 July, 2024. **Authors:** Leesa Ward.
 
+## Small pull requests, often
+
+Please favour raising small pull requests often over one or two large ones. This makes it easier for reviewers to understand the changes, and for you to make changes based on feedback. It also makes it easier to keep your branch up to date with the main branch as others' work gets merged in. 
+
+For example, instead of building an entire webpage and raising your first PR in week 10, raise a PR for the first component you build in week 3 or 4, then another for another component in week 5 or 6, etc.
+
+## One feature or change per pull request
+
+Please limit each pull request to one discrete unit of work, e.g., one new component for Redback UI, one new graph for a dashboard, one bugfix, etc. This makes it easier for reviewers to understand the changes and for feedback and discussion to be focused on a single topic.
+
+This usually means you will have a separate branch per feature or change, so you can continue working on another unit of work while the first is being reviewed.
+
+## Ensuring your pull request is ready for review
 
 Before raising a pull request, please ensure the below checks pass.
 


### PR DESCRIPTION
Last trimester, two issus we had in web dev were:
1. not seeing any PRs until the last third or so of the trimester, and 
2. those PRs being very large and often not cohesive with others' work (e.g., students building entire websites alone and not submitting anything until the final weeks). 

A third minor, but still not ideal, scenario was students submitting PRs that covered more than one thing, such as multiple distinct Redback UI components.

These doc changes explicitly request that students submit small PRs often, and keep each PR limited to a single discrete feature/change/bugfix. 