### PR TITLE
Added docker warning to the Data Warehouse documentations

### DIFF
--- a/docs/data-warehousing/Instructional Documents/Data Warehouse Administrator Guide.md
+++ b/docs/data-warehousing/Instructional Documents/Data Warehouse Administrator Guide.md
@@ -113,7 +113,7 @@ Flask-API: [http://10.137.0.149:5000/](http://10.137.0.149:5000/)
 
 ## The VM and Docker
 
-  
+⚠️ **WARNING:** Changes made to the Docker containers affect the shared production environment. These containers are **NOT** isolated per user.
 
 The VM uses a Docker instance to run 'containers' or apps (different software we use as tools e.g. MongoDB).
 

--- a/docs/data-warehousing/Instructional Documents/Data Warehouse Administrator Guide.md
+++ b/docs/data-warehousing/Instructional Documents/Data Warehouse Administrator Guide.md
@@ -113,7 +113,7 @@ Flask-API: [http://10.137.0.149:5000/](http://10.137.0.149:5000/)
 
 ## The VM and Docker
 
-⚠️ **WARNING:** Changes made to the Docker containers affect the shared production environment. These containers are **NOT** isolated per user.
+⚠️ **WARNING:** Changes made to the Docker containers inside the VM affect the shared production environment. These containers are **NOT** isolated per user.
 
 The VM uses a Docker instance to run 'containers' or apps (different software we use as tools e.g. MongoDB).
 


### PR DESCRIPTION
Added a new warning line to [docs/data-warehousing/Instructional Documents/Data Warehouse Administrator Guide.md](https://github.com/Redback-Operations/redback-documentation/compare/main...nouri-devv:redback-documentation:main#diff-211041cb46ff381df63a29c951f02cc2f831e61d261bebe0e28f4b5eab1f3ca4) as part of the documentations. 