### PR TITLE
Metadata injection script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "prestart": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
+    "prebuild": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
+    "predeploy": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/src/components/metadataInject.js
+++ b/src/components/metadataInject.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Directory to search
+const docsDir = path.resolve(__dirname, '../../docs');
+
+/**
+ * Recursively get all .md files in a directory.
+ * @param {string} dir - Directory path to search.
+ * @returns {string[]} - Array of file paths.
+ */
+function getMarkdownFiles(dir) {
+  let results = [];
+  const list = fs.readdirSync(dir);
+  list.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+    if (stat.isDirectory()) {
+      results = results.concat(getMarkdownFiles(filePath));
+    } else if (filePath.endsWith('.md')) {
+      results.push(filePath);
+    }
+  });
+  return results;
+}
+
+/**
+ * Retrieve the last Git commit metadata for a file.
+ * @param {string} file - File path.
+ * @returns {{ author: string, date: string }}
+ */
+function getGitMetadata(file) {
+  let author = 'Unknown';
+  let date = 'Unknown';
+  try {
+    author = execSync(`git log -1 --pretty=format:%an "${file}"`).toString().trim();
+    date = execSync(`git log -1 --pretty=format:%ad --date=short "${file}"`).toString().trim();
+  } catch (error) {
+    console.error(`Error getting git metadata for ${file}: ${error.message}`);
+  }
+  return { author, date };
+}
+
+/**
+ * Update a Markdown file by inserting last updated metadata.
+ * The metadata is inserted right after the YAML frontmatter, if present.
+ * If there is no frontmatter, the metadata is added at the top.
+ *
+ * @param {string} file - Path to the markdown file.
+ */
+function updateFile(file) {
+  const { author, date } = getGitMetadata(file);
+  const content = fs.readFileSync(file, 'utf8');
+
+  let yamlFront = '';
+  let restContent = content;
+
+  // Check if file starts with YAML frontmatter delimiter '---'
+  if (content.startsWith('---')) {
+    // Find the end of the YAML block (the second occurrence of '---')
+    const secondDelimiterIndex = content.indexOf('\n---', 3);
+    if (secondDelimiterIndex !== -1) {
+      // Include the entire YAML block (up to and including the second delimiter line)
+      const endOfYaml = content.indexOf('\n', secondDelimiterIndex + 1);
+      if (endOfYaml !== -1) {
+        yamlFront = content.substring(0, endOfYaml).trimEnd() + '\n';
+        restContent = content.substring(endOfYaml + 1);
+      }
+    }
+  }
+
+  const metadataBlock = `**Last updated by:** ${author}\n**Last updated on:** ${date}\n\n`;
+
+  // Insert metadata block after YAML frontmatter (if it exists) or at top
+  const updatedContent = yamlFront
+    ? `${yamlFront}\n${metadataBlock}${restContent}`
+    : `${metadataBlock}${restContent}`;
+
+  fs.writeFileSync(file, updatedContent, 'utf8');
+  console.log(`Updated metadata in ${file}`);
+}
+
+// Get all markdown files in the docs directory
+const markdownFiles = getMarkdownFiles(docsDir);
+
+// Process each file
+markdownFiles.forEach(updateFile);

--- a/src/components/metadataInject.js
+++ b/src/components/metadataInject.js
@@ -37,7 +37,7 @@ function getGitMetadata(file) {
   let date = 'Unknown';
   try {
     author = execSync(`git log -1 --pretty=format:%an "${file}"`).toString().trim();
-    date = execSync(`git log -1 --pretty=format:%ad --date=short "${file}"`).toString().trim();
+    date = execSync(`git log -1 --pretty=format:%ad --date=format:'%d/%m/%Y' "${file}"`).toString().trim();
   } catch (error) {
     console.error(`Error getting git metadata for ${file}: ${error.message}`);
   }
@@ -72,7 +72,7 @@ function updateFile(file) {
     }
   }
 
-  const metadataBlock = `**Last updated by:** ${author}\n**Last updated on:** ${date}\n\n`;
+  const metadataBlock = `**Last updated by:** ${author}, **Last updated on:** ${date}\n\n`;
 
   // Insert metadata block after YAML frontmatter (if it exists) or at top
   const updatedContent = yamlFront


### PR DESCRIPTION
A script that gets the meta data from git and adds the "Last updated by" and "Last updated on" data and adds it to the very top of the md files for each document.
I have also made it so it runs on pre-start, pre-build and pre-deploy.