### PR TITLE
Remove redundant prestart and predeploy scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "prestart": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
     "prebuild": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
-    "predeploy": "chmod +x ./src/components/metadataInject.js && node ./src/components/metadataInject.js",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
Removed the pre-start script as it will edit all the documents in development.
Removed the pre-deployment as its redundant.
Running the metadataInjection.js in pre-build is more than sufficient and the right way to do it.