### PR TITLE
Add scanner folder from redback-cyber repo (ignore __pycache__)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ package-lock.json
 package.json
 yarn.lock
 package-lock.json
+
+__pycache__/
+*.pyc
+*.pyo


### PR DESCRIPTION
This pull request adds the OWASP Top 10 Scanner from redback-cyber into this repository.

The scanner is a small Python tool that checks code and dependencies for common security issues from the OWASP Top 10, like injection flaws, sensitive data exposure, and security misconfigurations.

Adding it here makes it easier to keep the scanner documented, update rules, and share it across Redback projects.
This PR also updates .gitignore to ignore __pycache__/ and Python bytecode files.