### PR TITLE
fix(ci): allow OWASP scanner on fork pull requests

### DIFF
--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -1,7 +1,8 @@
 name: OWASP PR Scanner
 
 on:
-  pull_request_target:
+  pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -109,6 +110,8 @@ jobs:
           fi
 
       - name: Comment PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- change the OWASP scanner trigger from `pull_request_target` to `pull_request`
- only run it for PRs targeting `main`
- skip the PR comment on fork PRs where GitHub only gives the workflow a read-only token
- make sure a failed comment does not fail the actual scan

## Reason
This is to fix the issue that came up on #341 where the OWASP workflow could not safely check out code from a fork PR. The scan itself still runs and can pass/fail normally, it just avoids trying to write a comment when GitHub does not allow it.